### PR TITLE
Downgraded sdk to .dev version to make it work with Flutter Web

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/yuan-kuan/dorker
 author: kuan <yuankuan@gmail.com>
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: ">=2.3.0-dev.0.1 <3.0.0"
 
 dependencies:
   js: ^0.6.1+1


### PR DESCRIPTION
Flutter Web still depends on dart sdk 2.3.0-dev-*, which is considered lower than final 2.3.0 by the version resolution algorithm and `pub get` fails.

By downgrading sdk to dev build I am able to use this library with Fuutter Web.

All seem to work fine as the latest dart-sdk dev version contains all changes from the final release.